### PR TITLE
not raise if there is no :ll

### DIFF
--- a/lib/foursquare/venue_proxy.rb
+++ b/lib/foursquare/venue_proxy.rb
@@ -9,7 +9,6 @@ module Foursquare
     end
 
     def search(options={})
-      raise ArgumentError, "You must include :ll" unless options[:ll]
       response = @foursquare.get('venues/search', options)["groups"].inject({}) do |venues, group|
         venues[group["type"]] ||= []
         venues[group["type"]] += group["items"].map do |json|
@@ -34,7 +33,6 @@ module Foursquare
     private
 
     def search_group(name, options)
-      raise ArgumentError, "You must include :ll" unless options[:ll]
       response = @foursquare.get('venues/search', options)["groups"].detect { |group| group["type"] == name }
       response ? response["items"].map do |json|
         Foursquare::Venue.new(@foursquare, json)


### PR DESCRIPTION
Hi, 
according to the Foursquare API docs you can call it without  ll parameter if you have  intent: 'browse' and nw , se params (just my user case).
So I think it is not correct to raise on lack of  ll param. You can either have a more complex condition to raise or just dont raise. I think not raising is OK, foursquare is returning an error anyway if the params are not correct. 
