### PR TITLE
Add API version to requests

### DIFF
--- a/lib/foursquare/base.rb
+++ b/lib/foursquare/base.rb
@@ -2,13 +2,13 @@ module Foursquare
   class Base
     API = "https://api.foursquare.com/v2/"
 
-    def initialize(*args)
-      case args.size
-      when 1
-        @access_token = args.first
-      when 2
-        @client_id, @client_secret = args
-      else
+    def initialize(args = {})
+      @access_token  = args.fetch(:access_token, nil)
+      @client_id     = args.fetch(:client_id, nil)
+      @client_secret = args.fetch(:client_secret, nil)
+      @api_version   = args.fetch(:api_version, Date.new.strftime('%Y%m%d'))
+
+      unless @access_token || (@client_id && @client_secret)
         raise ArgumentError, "You need to pass either an access_token or client_id and client_secret"
       end
     end
@@ -34,6 +34,7 @@ module Foursquare
       Foursquare.log("GET #{API + path}")
       Foursquare.log("PARAMS: #{params.inspect}")
       merge_auth_params(params)
+      merge_version_params(params)
       response = JSON.parse(Typhoeus::Request.get(API + path, :params => params).body)
       Foursquare.log(response.inspect)
       error(response) || response["response"]
@@ -44,37 +45,38 @@ module Foursquare
       Foursquare.log("POST #{API + path}")
       Foursquare.log("PARAMS: #{params.inspect}")
       merge_auth_params(params)
+      merge_version_params(params)
       response = JSON.parse(Typhoeus::Request.post(API + path, :params => params).body)
       Foursquare.log(response.inspect)
       error(response) || response["response"]
     end
-    
+
     def authorize_url(redirect_uri)
       # http://developer.foursquare.com/docs/oauth.html
-      
+
       # check params
       raise "you need to define a client id before" if @client_id.blank?
       raise "no callback url provided" if redirect_uri.blank?
-      
+
       # params
       params = {}
       params["client_id"] = @client_id
       params["response_type"] = "code"
       params["redirect_uri"] = redirect_uri
-      
+
       # url
       oauth2_url('authenticate', params)
     end
-    
+
     def access_token(code, redirect_uri)
       # http://developer.foursquare.com/docs/oauth.html
-      
+
       # check params
       raise "you need to define a client id before" if @client_id.blank?
       raise "you need to define a client secret before" if @client_secret.blank?
       raise "no code provided" if code.blank?
       raise "no redirect_uri provided" if redirect_uri.blank?
-      
+
       # params
       params = {}
       params["client_id"] = @client_id
@@ -82,10 +84,10 @@ module Foursquare
       params["grant_type"] = "authorization_code"
       params["redirect_uri"] = redirect_uri
       params["code"] = code
-      
+
       # url
       url = oauth2_url('access_token', params)
-      
+
       # response
       # http://developer.foursquare.com/docs/oauth.html
       response = JSON.parse(Typhoeus::Request.get(url).body)
@@ -93,7 +95,7 @@ module Foursquare
     end
 
     private
-    
+
     def oauth2_url(method_name, params)
       "https://foursquare.com/oauth2/#{method_name}?#{params.to_query}"
     end
@@ -131,6 +133,10 @@ module Foursquare
       else
         params.merge!(:client_id => @client_id, :client_secret => @client_secret)
       end
+    end
+
+    def merge_version_params(params)
+      params.merge!(:v => @api_version)
     end
   end
 end

--- a/lib/foursquare/location.rb
+++ b/lib/foursquare/location.rb
@@ -31,7 +31,11 @@ module Foursquare
     def postal_code
       @json["postalCode"]
     end
-    
+
+    def cc
+      @json["cc"]
+    end
+
     def country
       @json["country"]
     end


### PR DESCRIPTION
per the new requirement for a `&v=YYYYMMDD` appended to all request query strings (see https://groups.google.com/forum/#!topic/foursquare-api/X60gF5Zi0k4)

This PR allows for the version to be set during instantiation of Foursquare::Base, or alternatively fall back to the default of sending today's date in `YYYMMDD` format.
