### PR TITLE
fixing date bug that was preventing requests.

### DIFF
--- a/lib/foursquare/base.rb
+++ b/lib/foursquare/base.rb
@@ -6,7 +6,7 @@ module Foursquare
       @access_token  = args.fetch(:access_token, nil)
       @client_id     = args.fetch(:client_id, nil)
       @client_secret = args.fetch(:client_secret, nil)
-      @api_version   = args.fetch(:api_version, Date.new.strftime('%Y%m%d'))
+      @api_version   = args.fetch(:api_version, Date.today.strftime('%Y%m%d'))
 
       unless @access_token || (@client_id && @client_secret)
         raise ArgumentError, "You need to pass either an access_token or client_id and client_secret"

--- a/lib/foursquare/venue_proxy.rb
+++ b/lib/foursquare/venue_proxy.rb
@@ -10,12 +10,8 @@ module Foursquare
 
     def search(options={})
       raise ArgumentError, "You must include :ll" unless options[:ll]
-      response = @foursquare.get('venues/search', options)["groups"].inject({}) do |venues, group|
-        venues[group["type"]] ||= []
-        venues[group["type"]] += group["items"].map do |json|
-          Foursquare::Venue.new(@foursquare, json)
-        end
-        venues
+      response = @foursquare.get('venues/search', options)["venues"].map do |venue |
+        Foursquare::Venue.new(@foursquare, venue)
       end
     end
 

--- a/lib/foursquare/venue_proxy.rb
+++ b/lib/foursquare/venue_proxy.rb
@@ -32,9 +32,7 @@ module Foursquare
     def search_group(name, options)
       raise ArgumentError, "You must include :ll" unless options[:ll]
       response = @foursquare.get('venues/search', options)["groups"].detect { |group| group["type"] == name }
-      response ? response["items"].map do |json|
-        Foursquare::Venue.new(@foursquare, json)
-      end : []
+      response ? response["items"].map{ |json| Foursquare::Venue.new(@foursquare, json) } : []
     end
   end
 end


### PR DESCRIPTION
Date.new does not return today's date and Foursquare apparently starting enforcing versions as of last night. Simply changing to Date.today resolves the errors.

[foursquare] {"meta"=>{"code"=>410, "errorType"=>"param_error", "errorDetail"=>"The Foursquare API no longer supports requests that pass in a version v <= 20120609. For more details see https://developer.foursquare.com/overview/versioning"}, "response"=>{}}
